### PR TITLE
Fixed build script

### DIFF
--- a/script/build.sh
+++ b/script/build.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
-browserify entry.js | uglifyjs > dist/main.js
+PATH=$(npm bin):$PATH
+if [[ ! -e dist ]]; then
+    mkdir dist
+fi
+browserify entry.js | uglify > dist/main.js
 cp src/main.css dist/main.css

--- a/script/watch.sh
+++ b/script/watch.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
+PATH=$(npm bin):$PATH
 watchify entry.js -o bundle.js -v


### PR DESCRIPTION
Issues with build script:

1. PATH didn't include locally installed node modules; either we should change `npm install` to `npm install -g` in the README or stick with this.
2. The `dist/` directory doesn't exist before the first build.
3. The installed version of uglify (0.1.5 at the time of writing) has `uglify` as the binary name, not `uglifyjs`.